### PR TITLE
Allow messages to flow into progress IPC

### DIFF
--- a/core/notifier.c
+++ b/core/notifier.c
@@ -189,10 +189,6 @@ static void process_notifier (RECOVERY_STATUS status, int event, int level, cons
 {
 	(void)level;
 
-	/* Check just in case a process want to send an info outside */
-	if (status != SUBPROCESS)
-	       return;
-
 	switch (event) {
 	case (CANCELUPDATE):
 		status = FAILURE;

--- a/corelib/progress_thread.c
+++ b/corelib/progress_thread.c
@@ -149,7 +149,7 @@ void swupdate_progress_info(RECOVERY_STATUS status, int cause, const char *info)
 {
 	struct swupdate_progress *prbar = &progress;
 	pthread_mutex_lock(&prbar->lock);
-	snprintf(prbar->msg.info, sizeof(prbar->msg.info), "{\"%d\": %s}",
+	snprintf(prbar->msg.info, sizeof(prbar->msg.info), "{\"%d\": \"%s\"}",
 			cause, info);
 	prbar->msg.infolen = strlen(prbar->msg.info);
 	prbar->msg.status = status;


### PR DESCRIPTION
There seems to be an error in the version we are using: Free text messages are not passed via swupdate progress API interface.
This seems to be later corrected here : https://github.com/sbabic/swupdate/commit/c20be59935cc77373756afc45628dcb0cae36100 by adding yet another listener and new message status `PROGRESS`. However in our case we probably want to receive all messages that swupdate daemon emits.
Alternatively we can limit it to essentials only.